### PR TITLE
PDT-3491 If the values aren't lists, just merge them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json_multi_merge"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Nic Wolff <nwolff@hearst.com>"]
 edition = "2021"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "json-multi-merge"
-version = "0.3.0"
+version = "0.3.1"
 description = "Rust-powered JSON merging with custom modifiers"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Instead of raising an error if a merged JSON has a key ending in `-history` whose value isn't a list, let's just merge it normally.